### PR TITLE
Configure Boost with autoconf macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ On the fly testcase making.
 # How to build
 
 You must have following softwares installed.
-- Autotools(autoconf,automake)
+- Autotools(autoconf,automake,autoconf-archive)
 - C++ Compiler that supports c++11(I recommend gcc or clang)
 
 At first,cd to shiranui dir.

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,10 @@ AM_INIT_AUTOMAKE([subdir-objects foreign -Wall -Werror -Wno-portability])
 CXXFLAGS="$CXXFLAGS -std=c++11 -O2"
 AC_LANG([C++])
 AC_PROG_CXX
+AX_BOOST_BASE
+AX_BOOST_PROGRAM_OPTIONS
+AX_BOOST_SYSTEM
+AX_BOOST_THREAD
 AC_CONFIG_HEADERS([config.hpp])
 AC_CONFIG_FILES([Makefile src/Makefile])
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,5 @@
 include $(top_srcdir)/flymake.mk
 bin_PROGRAMS = shiranui
 shiranui_SOURCES = main.cpp syntax/ast.cpp runtime/value.cpp runtime/runner.cpp runtime/environment.cpp server/server.cpp runtime/diver/diver.cpp runtime/cleaner.cpp tester/tester.cpp compiler/compiler.cpp
-shiranui_LDFLAGS = -lboost_program_options -lboost_system -lboost_thread
+shiranui_LDFLAGS = $(BOOST_PROGRAM_OPTIONS_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_THREAD_LIB)
 shiranui_CXXFLAGS = -Wall -Wextra -Wshadow -Wfloat-equal


### PR DESCRIPTION
This commit fixes the build failure `library not found for -lboost_thread` on
OS X / Homebrew and improves build.
